### PR TITLE
Install python package with pip

### DIFF
--- a/python/MANIFEST.in
+++ b/python/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.h

--- a/python/dballe.cc
+++ b/python/dballe.cc
@@ -1,6 +1,5 @@
 #include <Python.h>
 #include <wreport/python.h>
-#include "config.h"
 #include "common.h"
 #include "record.h"
 #include "db.h"

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,31 @@
+from setuptools import Extension, setup, command
+
+
+dballe_module = Extension(
+    'dballe',
+    sources=[
+        "common.cc", "cursor.cc", "dballe.cc", "db.cc", "record.cc",
+    ],
+    language="c++",
+    extra_compile_args=['-std=c++11'],
+)
+
+setup(
+    name="dballe",
+    version="7.6.0",
+    author="Enrico Zini",
+    author_email="enrico@enricozini.org",
+    maintainer="Emanuele Di Giacomo",
+    maintainer_email="edigiacomo@arpa.emr.it",
+    description="Fast on-disk database for meteorological data",
+    long_description="Fast on-disk database for meteorological data",
+    url="http://github.com/arpa-simc/dballe",
+    license="GPLv2+",
+    py_modules=[],
+    packages=['dballe'],
+    data_files=[],
+    zip_safe=False,
+    include_package_data=True,
+    exclude_package_data={},
+    ext_modules=[dballe_module],
+)

--- a/python/setup.py
+++ b/python/setup.py
@@ -1,4 +1,11 @@
 from setuptools import Extension, setup, command
+import subprocess
+
+
+def pkg_config_flags(options):
+    return [
+        s for s in subprocess.check_output(['pkg-config'] + options + ['libdballe']).decode().strip().split(" ") if s
+    ]
 
 
 dballe_module = Extension(
@@ -7,8 +14,8 @@ dballe_module = Extension(
         "common.cc", "cursor.cc", "dballe.cc", "db.cc", "record.cc",
     ],
     language="c++",
-    extra_compile_args=['-std=c++11'],
-    libraries=['dballe', 'wreport', 'lua', 'm', 'dl', 'sqlite3'],
+    extra_compile_args=pkg_config_flags(["--cflags"]) + ["-std=c++11"],
+    extra_link_args=pkg_config_flags(["--libs"]),
 )
 
 setup(

--- a/python/setup.py
+++ b/python/setup.py
@@ -36,4 +36,5 @@ setup(
     include_package_data=True,
     exclude_package_data={},
     ext_modules=[dballe_module],
+    install_requires=['wreport'],
 )

--- a/python/setup.py
+++ b/python/setup.py
@@ -2,12 +2,13 @@ from setuptools import Extension, setup, command
 
 
 dballe_module = Extension(
-    'dballe',
+    '_dballe',
     sources=[
         "common.cc", "cursor.cc", "dballe.cc", "db.cc", "record.cc",
     ],
     language="c++",
     extra_compile_args=['-std=c++11'],
+    libraries=['dballe', 'wreport', 'lua', 'm', 'dl', 'sqlite3'],
 )
 
 setup(


### PR DESCRIPTION
Using pip is the only way I know to install this package in a virtualenv.

From source code (using `setuptools` branch):

    $ pip install -e "git+https://github.com/arpa-simc/dballe.git@setuptools#egg=dballe&subdirectory=python"

But the package could be pushed in pypi and the installation is simpler

    $ pip install dballe