### PR TITLE
Catch wreport exceptions in Reader::read_file

### DIFF
--- a/dballe/cmdline/processor.cc
+++ b/dballe/cmdline/processor.cc
@@ -853,6 +853,10 @@ void Reader::read_file(const std::list<std::string>& fnames, Action& action)
                 processed = false;
                 if (verbose)
                     fprintf(stderr, "%s\n", pe.what());
+            } catch (wreport::error_notfound& e) {
+                processed = false;
+                if (verbose)
+                    fprintf(stderr, "%s:\n", e.what());
             } catch (std::exception& e) {
                 if (verbose)
                     fprintf(stderr, "%s:#%d: %s\n", file->pathname().c_str(), item.idx, e.what());

--- a/dballe/cmdline/processor.cc
+++ b/dballe/cmdline/processor.cc
@@ -857,6 +857,10 @@ void Reader::read_file(const std::list<std::string>& fnames, Action& action)
                 processed = false;
                 if (verbose)
                     fprintf(stderr, "%s:\n", e.what());
+            } catch (wreport::error_consistency& e) {
+                processed = false;
+                if (verbose)
+                    fprintf(stderr, "%s:\n", e.what());
             } catch (std::exception& e) {
                 if (verbose)
                     fprintf(stderr, "%s:#%d: %s\n", file->pathname().c_str(), item.idx, e.what());


### PR DESCRIPTION
Catch `wreport::error_notfound` and `wreport::error_consistency` in `Reader::read_file` (e.g. thrown while importing).

Maybe we could handle the generic `std::exception` too instead of rethrowing it?

https://github.com/ARPA-SIMC/dballe/blob/6506d01640d0e50e666313eecce8e57539463cf8/dballe/cmdline/processor.cc#L864-L868