### PR TITLE
Add level 161 Depth below water surface

### DIFF
--- a/doc/fapi_ltypes.md
+++ b/doc/fapi_ltypes.md
@@ -43,8 +43,9 @@ where possible.
 | 112         | 116 Reserved                           |                             |
 | 117         | Mixed Layer Depth                      | mm                          |
 | 118-159 Reserved |                                        |                             |
-| 160         | Depth Below Sea Level                  | mm                          |
-| 161-191 Reserved |                                        |                             |
+| 160         | Depth Below Mean Sea Level             | mm                          |
+| 161         | Depth Below water surface              | mm                          |
+| 162-191 Reserved |                                        |                             |
 | 200         | Entire atmosphere (considered as a single layer) |                             |
 | 201         | Entire ocean (considered as a single layer) |                             |
 | 204         | Highest tropospheric freezing level    |                             |


### PR DESCRIPTION
Added type of surface 161 according to latest [WMO table 4.5](http://www.wmo.int/pages/prog/www/WMOCodes/WMO306_vI2/LatestVERSION/LatestVERSION.html), now level 160 is interpreted as depth below *mean* sea level. I wonder whether modifications in code are required to accept this new level type.
Code 161 will be used e.g. for buoy observations (Nausicaa).