### PR TITLE
"tag" option clamps the values and sets B33192=0

### DIFF
--- a/dballe/msg/domain_errors.cc
+++ b/dballe/msg/domain_errors.cc
@@ -13,13 +13,13 @@ class TagDomainErrors : public wreport::options::DomainErrorHook
 {
     void handle_domain_error_int(wreport::Var& var, int32_t val) override
     {
-        var.unset();
+        var.set(val < var.info()->imin ? var.info()->imin : var.info()->imax);
         var.seta(newvar(WR_VAR(0, 33, 192), 0));
     }
 
     void handle_domain_error_double(wreport::Var& var, double val) override
     {
-        var.unset();
+        var.set(val < var.info()->dmin ? var.info()->dmin : var.info()->dmax);
         var.seta(newvar(WR_VAR(0, 33, 192), 0));
     }
 } domain_errors_tag;

--- a/dballe/msg/domain_errors.cc
+++ b/dballe/msg/domain_errors.cc
@@ -7,24 +7,19 @@ namespace dballe {
 namespace impl {
 namespace msg {
 
-namespace {
-
-class TagDomainErrors : public wreport::options::DomainErrorHook
+void TagDomainErrors::handle_domain_error_int(wreport::Var& var, int32_t val)
 {
-    void handle_domain_error_int(wreport::Var& var, int32_t val) override
-    {
-        var.set(val < var.info()->imin ? var.info()->imin : var.info()->imax);
-        var.seta(newvar(WR_VAR(0, 33, 192), 0));
-    }
-
-    void handle_domain_error_double(wreport::Var& var, double val) override
-    {
-        var.set(val < var.info()->dmin ? var.info()->dmin : var.info()->dmax);
-        var.seta(newvar(WR_VAR(0, 33, 192), 0));
-    }
-} domain_errors_tag;
-
+    var.set(val < var.info()->imin ? var.info()->imin : var.info()->imax);
+    var.seta(newvar(WR_VAR(0, 33, 192), 0));
 }
+
+void TagDomainErrors::handle_domain_error_double(wreport::Var& var, double val)
+{
+    var.set(val < var.info()->dmin ? var.info()->dmin : var.info()->dmax);
+    var.seta(newvar(WR_VAR(0, 33, 192), 0));
+}
+
+TagDomainErrors domain_errors_tag;
 
 
 WreportVarOptionsForImport::WreportVarOptionsForImport(dballe::ImporterOptions::DomainErrors val)

--- a/dballe/msg/domain_errors.h
+++ b/dballe/msg/domain_errors.h
@@ -26,6 +26,16 @@ public:
     ~WreportVarOptionsForImport();
 };
 
+/**
+ * Hook for out of range values
+ */
+class TagDomainErrors : public wreport::options::DomainErrorHook
+{
+    void handle_domain_error_int(wreport::Var& var, int32_t val) override;
+    void handle_domain_error_double(wreport::Var& var, double val) override;
+};
+
+
 }
 }
 }

--- a/dballe/msg/json_codec-test.cc
+++ b/dballe/msg/json_codec-test.cc
@@ -96,7 +96,7 @@ add_method("domain_tag", []() {
             // Would throw: wreport::error_domain Value -30 is outside the range [-20,1048554] for 013013 (TOTAL SNOW DEPTH)
             const wreport::Var* val = dest->get(Level(1), Trange::instant(), WR_VAR(0, 13, 13));
             wassert_true(val);
-            wassert_false(val->isset());
+            wassert(actual(*val) == -20);
             const wreport::Var* a = val->enqa(WR_VAR(0, 33, 192));
             wassert_true(a);
             wassert(actual(a->enqi()) == 0);

--- a/dballe/msg/wr_codec-test.cc
+++ b/dballe/msg/wr_codec-test.cc
@@ -82,7 +82,7 @@ add_method("domain_tag", []() {
             // Would throw: wreport::error_domain: Value 329.2 is outside the range [0,327.66] for B22043 (SEA/WATER TEMPERATURE)
             const wreport::Var* val = dest->get(Level(1), Trange::instant(), WR_VAR(0, 22, 43));
             wassert_true(val);
-            wassert_false(val->isset());
+            wassert(actual(*val) == 327.66);
             const wreport::Var* a = val->enqa(WR_VAR(0, 33, 192));
             wassert_true(a);
             wassert(actual(a->enqi()) == 0);

--- a/python/importer.cc
+++ b/python/importer.cc
@@ -200,7 +200,8 @@ Constructor: Importer(encoding: str, simplified: bool=True, domain_errors="raise
                     the range for its variable. "raise" (the default) raises an
                     exception. "unset" changes the value to be unset. "clamp"
                     changes the value to the nearest valid extreme of the
-                    domain. "tag" unsets the value and sets attribute B33192=0
+                    domain. "tag" changes the value to the nearest valid
+                    extreme of the domain and sets attribute B33192=0
 
 When a message is imported in simplified mode, the actual context information
 will be stored as data attributes.

--- a/python/test-importer.py
+++ b/python/test-importer.py
@@ -147,7 +147,7 @@ class TestImporter(MessageTestMixin, unittest.TestCase):
         importer = dballe.Importer("BUFR", domain_errors="tag")
         msgs = importer.from_binary(binmsg)
         val = msgs[0].get(dballe.Level(1), dballe.Trange(254, 0, 0), "B22043")
-        self.assertFalse(val.isset)
+        self.assertEqual(val.enqd(), 327.66)
         a = val.enqa("B33192")
         self.assertTrue(a)
         self.assertEqual(a.enqi(), 0)


### PR DESCRIPTION
The option `domain_errors=tag` clamps the value instead of unsetting it.

In addition, the class `TagDomainErrors` is now public: this is useful for `meteo-vm2`, where I had to replicate the code.