### PR TITLE
Fix -Werror=range-loop-construct in fc34

### DIFF
--- a/dballe/db/summary_utils.cc
+++ b/dballe/db/summary_utils.cc
@@ -128,7 +128,7 @@ void StationEntry<Station>::to_json(core::JSONWriter& writer) const
     writer.add(station);
     writer.add("v");
     writer.start_list();
-    for (const auto entry: *this)
+    for (const auto& entry: *this)
         entry.to_json(writer);
     writer.end_list();
     writer.end_mapping();

--- a/dballe/msg/wr_exporters/synop.cc
+++ b/dballe/msg/wr_exporters/synop.cc
@@ -58,7 +58,7 @@ struct Synop : public Template
                     switch (ctx.trange.pind)
                     {
                         case 1:
-                            for (const auto v: ctx.values)
+                            for (const auto& v: ctx.values)
                             {
                                 switch (v->code())
                                 {


### PR DESCRIPTION
Il costrutto:

    for (const auto valore: valori)

è diventato un errore nel compilatore di Fedora 34. La copia del valore, introdotta dall'assenza di `&`, sembra non servire perché il valore viene solo letto. Quindi ho aggiunto gli `&` per usare un riferimento e questo sembra risolvere l'errore di compilazione.

Posso fare il merge?